### PR TITLE
Update visuals.py

### DIFF
--- a/visuals.py
+++ b/visuals.py
@@ -115,7 +115,7 @@ def evaluate(results, accuracy, f1):
     
     # Aesthetics
     pl.suptitle("Performance Metrics for Three Supervised Learning Models", fontsize = 16, y = 1.10)
-    pl.tight_layout()
+    pl.subplots_adjust(top=0.85, bottom=0., left=0.10, right=0.95, hspace=0.3,wspace=0.35)
     pl.show()
     
 


### PR DESCRIPTION
最新版本matplotlib2.2.2中，这一行代码会使得图画排版错误
```python
pl.tight_layout()
```
![screenshot from 2018-03-26 00-07-33](https://user-images.githubusercontent.com/16526817/37877225-4e771d5a-308a-11e8-96bf-ebf960a9914c.png)

去掉上面的代码，增加下面这行代码后，无论在任意一个版本的matplotlib都会显示正确的图画
```python
pl.subplots_adjust(top=0.85, bottom=0., left=0.10, right=0.95, hspace=0.3,wspace=0.35)
```

![screenshot from 2018-03-26 00-14-02](https://user-images.githubusercontent.com/16526817/37877247-9b69ef3e-308a-11e8-968a-a206788c064d.png)
